### PR TITLE
Add diff() function for absolute difference between two unsigned coords

### DIFF
--- a/src/bddata.cpp
+++ b/src/bddata.cpp
@@ -119,7 +119,7 @@ void BDData::loadBDFile(const std::string& filename)
 
          firstPos += g_SpacerBeforeAfter; // ??? ask Kai
          secondPos += g_SpacerBeforeAfter;
-         if (firstChrName == secondChrName && secondChrName != "" && abs(firstPos - secondPos) < 500) {
+         if (firstChrName == secondChrName && secondChrName != "" && diff(firstPos, secondPos) < 500) {
             continue;
          }
          if ( firstChrName!="" && secondChrName!="") {
@@ -179,17 +179,17 @@ void SortRPByChrPos(std::vector <RP_READ> & Reads_RP) { // no interchromosome RP
 }*/
 bool RecipicalOverlap(RP_READ & first, RP_READ & second)
 {
-   int distance = 1000;
-   if (abs(first.PosA - first.PosA1) > distance) {
+   unsigned distance = 1000;
+   if (diff(first.PosA, first.PosA1) > distance) {
       return false;
    }
-   if (abs(first.PosB - first.PosB1) > distance) {
+   if (diff(first.PosB, first.PosB1) > distance) {
       return false;
    }
-   if (abs(second.PosA - second.PosA1) > distance) {
+   if (diff(second.PosA, second.PosA1) > distance) {
       return false;
    }
-   if (abs(second.PosB - second.PosB1) > distance) {
+   if (diff(second.PosB, second.PosB1) > distance) {
       return false;
    }
    float cutoff = 0.9;
@@ -424,7 +424,7 @@ void ModifyRP(std::vector <RP_READ> & Reads_RP)
          Reads_RP[first].PosB = Reads_RP[first].PosB + Reads_RP[first].ReadLength;
          Reads_RP[first].PosB1 = Reads_RP[first].PosB1 + Reads_RP[first].ReadLength;
       }
-      if (Reads_RP[first].ChrNameA == Reads_RP[first].ChrNameB && abs(Reads_RP[first].PosA - Reads_RP[first].PosB) < 500) {
+      if (Reads_RP[first].ChrNameA == Reads_RP[first].ChrNameB && diff(Reads_RP[first].PosA, Reads_RP[first].PosB) < 500) {
          Reads_RP[first].Visited = true;
       }
       //std::cout << "Final: " << Reads_RP[first].ChrNameA << " " << Reads_RP[first].DA << " " << Reads_RP[first].PosA << "\t" << Reads_RP[first].ChrNameB << " " << Reads_RP[first].DB << " " << Reads_RP[first].PosB << std::endl;
@@ -718,12 +718,12 @@ void BDData::UpdateBD(ControlState & currentState)
                                << "\t" << secondPos2 - g_SpacerBeforeAfter
                                << "\t" << currentState.Reads_RP_Discovery[read_index].DB
                                << "\t" << secondPos2 - secondPos << "\t"
-                               << abs((int)secondPos - (int)firstPos) << "\tSupport: " << currentState.Reads_RP_Discovery[read_index].NumberOfIdentical << "\t";
+                               << diff(secondPos, firstPos) << "\tSupport: " << currentState.Reads_RP_Discovery[read_index].NumberOfIdentical << "\t";
                   DisplayBDSupportPerSample(currentState.Reads_RP_Discovery[read_index], RPoutputfile);
                   RPoutputfile << std::endl;
                   std::cout << "adding " << firstChrName << " " << ( (firstPos > g_SpacerBeforeAfter) ? firstPos - g_SpacerBeforeAfter : 1) << "\t" << firstPos2 - g_SpacerBeforeAfter << "\t" << currentState.Reads_RP_Discovery[read_index].DA << "\t" << firstPos2 - firstPos << "\t"
                             << "\t" << secondChrName << " " << ( (secondPos > g_SpacerBeforeAfter) ? secondPos - g_SpacerBeforeAfter : 1)  << "\t" << secondPos2 - g_SpacerBeforeAfter << "\t" << currentState.Reads_RP_Discovery[read_index].DB << "\t" << secondPos2 - secondPos << "\t"
-                            << " to BD events. " << abs((int)secondPos - (int)firstPos) << " Support: " << currentState.Reads_RP_Discovery[read_index].NumberOfIdentical << std::endl;
+                            << " to BD events. " << diff(secondPos, firstPos) << " Support: " << currentState.Reads_RP_Discovery[read_index].NumberOfIdentical << std::endl;
                }
             }
 

--- a/src/genotyping.cpp
+++ b/src/genotyping.cpp
@@ -124,7 +124,7 @@ void doGenotyping (ControlState & CurrentState, UserDefinedSettings* userSetting
    // step 4 for each variant, do genotyping
    for (unsigned SV_index =0; SV_index < AllSV4Genotyping.size(); SV_index++) {
       // step 4.1 if type == DEL, GenotypeDel
-      if (AllSV4Genotyping[SV_index].ChrA == AllSV4Genotyping[SV_index].ChrB && abs(AllSV4Genotyping[SV_index].PosA - AllSV4Genotyping[SV_index].PosB) < SV_Genotype_Cutoff) {
+      if (AllSV4Genotyping[SV_index].ChrA == AllSV4Genotyping[SV_index].ChrB && diff(AllSV4Genotyping[SV_index].PosA, AllSV4Genotyping[SV_index].PosB) < SV_Genotype_Cutoff) {
          std::cout << "Skip One SV " << OneSV.Type << " " << OneSV.ChrA << " " << OneSV.PosA << " "
                    << OneSV.CI_A << " " << OneSV.ChrB << " " << OneSV.PosB << " "
                    << OneSV.CI_B << std::endl;

--- a/src/pindel.cpp
+++ b/src/pindel.cpp
@@ -1554,7 +1554,7 @@ void MergeInterChr(ControlState& currentState, UserDefinedSettings *usersettings
             continue;
          }
          if (All[index_a].FirstChrName == All[index_b].FirstChrName && All[index_a].SecondChrName == All[index_b].SecondChrName) {
-            if (abs(All[index_a].FirstPos - All[index_b].FirstPos) < 10 && abs(All[index_a].SecondPos - All[index_b].SecondPos) < 10 && All[index_a].NumSupport + All[index_b].NumSupport >= cutoff) {
+            if (diff(All[index_a].FirstPos, All[index_b].FirstPos) < 10 && diff(All[index_a].SecondPos, All[index_b].SecondPos) < 10 && All[index_a].NumSupport + All[index_b].NumSupport >= cutoff) {
 
                INToutputfile << "chr\t" << All[index_a].FirstChrName << "\tpos\t" << unsigned((All[index_a].FirstPos + All[index_b].FirstPos) / 2) << "\tchr\t" << All[index_a].SecondChrName << "\tpos\t"
                              << unsigned((All[index_a].SecondPos + All[index_b].SecondPos) / 2) << "\tseq\t" << All[index_a].InsertedSequence << "\tsupport\t" << All[index_a].NumSupport + All[index_b].NumSupport << "\tINFOR\t"

--- a/src/pindel.h
+++ b/src/pindel.h
@@ -740,4 +740,9 @@ void safeGetline(std::istream& is, std::string& t);
 
 void SearchFarEnds( const std::string & chromosomeSeq, std::vector<SPLIT_READ>& reads, const Chromosome& currentChromosome);
 
+static inline unsigned diff(unsigned a, unsigned b)
+{
+    return (a > b)? a - b : b - a;
+}
+
 #endif /* PINDEL_H */


### PR DESCRIPTION
Using abs(pos1-pos2) has potential to overflow and, when pos1/pos2 are
unsigned, fails to compile when there are ambiguous signed int/signed
long/etc std::abs() functions to choose between.  Avoid these issues
by introducing a function that does what is really needed, namely
finding the difference without sign between the two coordinates.